### PR TITLE
 Add README for OctoAcme Project Management Docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,32 @@
+# OctoAcme Project Management Docs
+
+Welcome to the centralized hub for OctoAcme’s project management processes, roles, and best practices. This documentation helps all team members—new and seasoned—quickly ramp up on how work happens at OctoAcme, ensuring every project is delivered efficiently and with clarity.
+
+---
+
+## Project Management at OctoAcme: Summary
+
+OctoAcme’s project management processes follow a structured but flexible lifecycle that starts from project initiation and moves through planning, execution, release, and continuous improvement. Each project begins with a one-pager outlining its problem statement, objectives, and success metrics. Structured planning breaks high-level goals into actionable backlogs and timelines, with early identification of dependencies and risks. These efforts culminate in transparent documentation and alignment, ensuring all stakeholders and contributors are equipped for success, while decision gates and checklists guide movement from one phase to the next.
+
+The success of this approach relies on clear roles and responsibilities: Project Managers coordinate delivery, scheduling, and cross-team communication; Product Managers own product vision, value, and prioritization; Developers focus on implementation and technical review; QA and Testers uphold quality against acceptance criteria; Stakeholders provide feedback and approvals. Well-defined ownership and expectations foster effective, focused meetings and timely escalation of blockers or risks.
+
+Communication is a backbone of OctoAcme’s processes. Weekly PM-PdM syncs, standups, routine status reports, and milestone demos ensure everyone is informed, risks are surfaced early, and feedback is actioned swiftly. Standardized templates for updates, risks, and incident management create consistency—so nothing critical falls through the cracks regardless of who is leading or supporting the work.
+
+Quality assurance is embedded at every step: from test plans and CI automation, to release checklists with rollback/incident protocols, to regular retrospectives where the team turns lessons learned into actionable improvements. Metrics for velocity, risk, and outcomes are monitored closely, supporting a culture of psychological safety, learning, and continuous improvement.
+
+---
+
+## Table of Contents
+
+- [Project Management Overview](./octoacme-project-management-overview.md)
+- [Project Initiation Guide](./octoacme-project-initiation.md)
+- [Project Planning](./octoacme-project-planning.md)
+- [Execution & Tracking](./octoacme-execution-and-tracking.md)
+- [Risk Management & Communication](./octoacme-risks-and-communication.md)
+- [Release & Deployment Guide](./octoacme-release-and-deployment.md)
+- [Retrospective & Continuous Improvement](./octoacme-retrospective-and-continuous-improvement.md)
+- [Roles and Personas](./octoacme-roles-and-personas.md)
+
+Refer to each document for actionable steps, checklists, escalation paths, and templates. If you have suggested improvements or questions, submit an issue or pull request.
+
+---


### PR DESCRIPTION
Adds a README with a summary of OctoAcme’s project management processes and direct links to all docs.
Closes #2.